### PR TITLE
Fix pop down button and MLH logo position in mobile view

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2202,5 +2202,5 @@ section {
   margin-right: 7%;
 }
 .mlh-button {
-  margin-right: 80px;
+  margin-right: 45px;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2202,5 +2202,5 @@ section {
   margin-right: 7%;
 }
 .mlh-button {
-  margin-right: 45px;
+  margin-right: 35px;
 }

--- a/index.html
+++ b/index.html
@@ -1599,7 +1599,7 @@
   })();
   </script>
   <!--End of Tawk.to Script-->
-  <a id="mlh-trust-badge" style="display:block;max-width:100px;min-width:60px;position:fixed;right:20px;top:0;width:10%;z-index:10000" href="https://mlh.io/seasons/2022/events?utm_source=apac-hackathon&utm_medium=TrustBadge&utm_campaign=2022-season&utm_content=red" target="_blank"><img src="https://s3.amazonaws.com/logged-assets/trust-badge/2022/mlh-trust-badge-2022-red.svg" alt="Major League Hacking 2022 Hackathon Season" style="width:100%"></a>
+  <a id="mlh-trust-badge" style="display:block;max-width:100px;min-width:60px;position:fixed;right:5px;top:0;width:10%;z-index:10000" href="https://mlh.io/seasons/2022/events?utm_source=apac-hackathon&utm_medium=TrustBadge&utm_campaign=2022-season&utm_content=red" target="_blank"><img src="https://s3.amazonaws.com/logged-assets/trust-badge/2022/mlh-trust-badge-2022-red.svg" alt="Major League Hacking 2022 Hackathon Season" style="width:100%"></a>
   <script defer async src="https://apply.devfolio.co/v2/sdk.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -1599,7 +1599,7 @@
   })();
   </script>
   <!--End of Tawk.to Script-->
-  <a id="mlh-trust-badge" style="display:block;max-width:100px;min-width:60px;position:fixed;right:50px;top:0;width:10%;z-index:10000" href="https://mlh.io/seasons/2022/events?utm_source=apac-hackathon&utm_medium=TrustBadge&utm_campaign=2022-season&utm_content=red" target="_blank"><img src="https://s3.amazonaws.com/logged-assets/trust-badge/2022/mlh-trust-badge-2022-red.svg" alt="Major League Hacking 2022 Hackathon Season" style="width:100%"></a>
+  <a id="mlh-trust-badge" style="display:block;max-width:100px;min-width:60px;position:fixed;right:20px;top:0;width:10%;z-index:10000" href="https://mlh.io/seasons/2022/events?utm_source=apac-hackathon&utm_medium=TrustBadge&utm_campaign=2022-season&utm_content=red" target="_blank"><img src="https://s3.amazonaws.com/logged-assets/trust-badge/2022/mlh-trust-badge-2022-red.svg" alt="Major League Hacking 2022 Hackathon Season" style="width:100%"></a>
   <script defer async src="https://apply.devfolio.co/v2/sdk.js"></script>
 </body>
 


### PR DESCRIPTION
Shifted both the things to the right in mobile view to improve the UI.
Kindly merge under hacktoberfest-accepted.