### PR TITLE
Added links to Address & Email in Team & Events pages

### DIFF
--- a/events.html
+++ b/events.html
@@ -237,11 +237,16 @@
       <div class="col-lg-3 col-md-6 footer-contact">
         <h3>Hack<span>4</span>Bengal</h3>
         <p>
-          DG 1/2 New Town, Action Area 1 <br>
-          Kolkata - 700156<br>
-          West Bengal, India <br><br>
+          <a href="https://g.page/snuindia?share">
+            DG 1/2 New Town, Action Area 1 <br />
+            Kolkata - 700156<br />
+            West Bengal, India <br />
+          </a>
+          <br />
           <!-- <strong>Phone:</strong> +1 5589 55488 55<br> -->
-          <strong>Email:</strong> hack4bengal@gmail.com<br>
+          <a href="mailto:hack4bengal@gmail.com"
+            ><strong>Email:</strong> hack4bengal@gmail.com<br
+          /></a>
         </p>
       </div>
 

--- a/team.html
+++ b/team.html
@@ -1031,15 +1031,20 @@
         <div class="row">
 
           <div class="col-lg-3 col-md-6 footer-contact">
-            <h3>Hack<span>4</span>Bengal</h3>
-            <p>
-              DG 1/2 New Town, Action Area 1 <br>
-              Kolkata - 700156<br>
-              West Bengal, India <br><br>
-              <!-- <strong>Phone:</strong> +1 5589 55488 55<br> -->
-              <strong>Email:</strong> hack4bengal@gmail.com<br>
-            </p>
-          </div>
+              <h3>Hack<span>4</span>Bengal</h3>
+              <p>
+                <a href="https://g.page/snuindia?share">
+                  DG 1/2 New Town, Action Area 1 <br />
+                  Kolkata - 700156<br />
+                  West Bengal, India <br />
+                </a>
+                <br />
+                <!-- <strong>Phone:</strong> +1 5589 55488 55<br> -->
+                <a href="mailto:hack4bengal@gmail.com"
+                  ><strong>Email:</strong> hack4bengal@gmail.com<br
+                /></a>
+              </p>
+            </div>
 
           <div class="col-lg-2 col-md-6 footer-links">
             <h4>Useful Links</h4>


### PR DESCRIPTION
## What

Added links to Address & Email in Team & Events pages. The PR tries to resolve #76.


## Screenshots

`team.html`

![image](https://user-images.githubusercontent.com/55836816/194741193-44f13d9e-4db2-4685-acc8-a068c398e222.png)

`events.html`

![image](https://user-images.githubusercontent.com/55836816/194741226-33d34470-ade2-46b4-915c-dbacd26b2b83.png)
